### PR TITLE
Fatalen Fehler beim Import vermeiden

### DIFF
--- a/functions/icalimport.php
+++ b/functions/icalimport.php
@@ -23,6 +23,7 @@ function sunflower_icalimport( $url = false, $auto_categories = false ) {
 
 		$ical->initUrl( $url, $username = null, $password = null, $userAgent = null );
 	} catch ( \Exception $e ) {
+		// @TODO Error Log?
 		return false;
 	}
 
@@ -191,7 +192,7 @@ function sunflower_import_icals( $force = false ) {
 		}
 
 		$response        = sunflower_icalimport( $url, $auto_categories );
-		$ids_from_remote = array_merge( $ids_from_remote, $response[0] );
+		$ids_from_remote = is_array($response) ? array_merge( $ids_from_remote, $response[0] ) : $ids_from_remote;
 	}
 
 	$deleted_on_remote = array_diff( sunflower_get_events_having_uid(), $ids_from_remote );


### PR DESCRIPTION
Ein Fehler vom Typ E_ERROR wurde in der Zeile 194 der Datei /…/wp-content/themes/sunflower/functions/icalimport.php verursacht. Fehlermeldung: Uncaught TypeError: array_merge(): Argument #2 must be of type array, null given in /…/wp-content/themes/sunflower/functions/icalimport.php:194