### PR TITLE
Add space between 'E-Mail' label and the actual email in contact form

### DIFF
--- a/functions/contact-form.php
+++ b/functions/contact-form.php
@@ -23,7 +23,7 @@ function sunflower_contact_form() {
 	$to       = get_sunflower_setting( 'sunflower_contact_form_to' ) ?: get_option( 'admin_email' );
 
 	$subject = __( 'New contact form', 'sunflower' );
-	$message = sprintf( "Name: %s\nE-Mail:%s\n\n%s", $name, $mail, $message );
+	$message = sprintf( "Name: %s\nE-Mail: %s\n\n%s", $name, $mail, $message );
 
 	if ( ! empty( $mail ) ) {
 		$headers = 'Reply-To: ' . $mail;


### PR DESCRIPTION
This issue is bugging me for quite a while now, so i decided to just create a PR. :)

There is no space between the 'E-Mail:' label and the actual email, which results in the label being added to the 'mailto://' email link in many mail apps. I don't have much php experience, so feel free to correct me if i'm misunderstanding something here and this change has do be done in some localization file. Thank you very much!