### PR TITLE
Update _navigation.scss um in mulitlevel-Naviagtion auch Parent zu ma…

### DIFF
--- a/sass/_accordion.scss
+++ b/sass/_accordion.scss
@@ -5,16 +5,21 @@
         font-size: 25px;
         font-family: PTSans !important;
 
+        color: var(--wp--preset--color--white);
+	    padding: var(--wp--preset--spacing--20);
+		background-color: var(--bs-primary);
+	
         &::before {
             display: none !important;
         }
 
         &::after {
-
             content: ">";
             padding-left: 1em;
             font-weight: 700;
-            position: relative;
+            position:absolute;
+		    right: var(--wp--preset--spacing--40);
+		    color: var(--wp--preset--color--white);
         }
     }
 }

--- a/sass/_navigation.scss
+++ b/sass/_navigation.scss
@@ -113,6 +113,11 @@
                 }
             }
 
+            .menu-item.menu-item-has-children:has(li.menu-item.current-menu-parent) {
+	            > a.nav-link {		
+                	color: $primary;
+                }
+
             .nav-link {
                 color: $body-color;
                 font-size: 18px;


### PR DESCRIPTION
…rkieren

Bei multilevel-Navigationen wird nur das direkte Parent-Element grün hervorgehoben. Nicht aber das parent des parents. Dies wird hierdurch behoben.

-> https://github.com/verdigado/sunflower/issues/451