### PR TITLE
Update um in mulitlevel-Naviagtion auch Parent zu markieren

### DIFF
--- a/sass/_navigation.scss
+++ b/sass/_navigation.scss
@@ -113,6 +113,11 @@
                 }
             }
 
+            .menu-item.menu-item-has-children:has(li.menu-item.current-menu-parent) {
+	            > a.nav-link {		
+                	color: $primary;
+                }
+
             .nav-link {
                 color: $body-color;
                 font-size: 18px;

--- a/sass/_navigation.scss
+++ b/sass/_navigation.scss
@@ -113,11 +113,6 @@
                 }
             }
 
-            .menu-item.menu-item-has-children:has(li.menu-item.current-menu-parent) {
-	            > a.nav-link {		
-                	color: $primary;
-                }
-
             .nav-link {
                 color: $body-color;
                 font-size: 18px;
@@ -306,6 +301,15 @@
             .dropdown-menu {
                 flex: 100%;
                 top: 100%;
+            }
+
+
+            &:has(li.menu-item.current-menu-parent) {
+
+                > a.nav-link {
+                    color: $primary;
+                }
+
             }
 
         }


### PR DESCRIPTION
Update _navigation.scss um in mulitlevel-Naviagtion auch Parent zu markieren

Bei multilevel-Navigationen wird nur das direkte Parent-Element grün hervorgehoben. Nicht aber das parent des parents. Dies wird hierdurch behoben.

-> https://github.com/verdigado/sunflower/issues/451