### PR TITLE
Add option to exclude categories from latest posts list

### DIFF
--- a/functions/blocks/latest-posts.php
+++ b/functions/blocks/latest-posts.php
@@ -1,20 +1,32 @@
 <?php
 
+function map_slug_list_to_ids( $categoryList ) {
+	$categories = array_map( 'trim', explode( ',', $categoryList ) );
+	return array_map(
+		fn( $value ) => $value->term_id,
+		array_map( 'get_category_by_slug', $categories )
+	);
+}
+
 function sunflower_latest_posts_render( $block_attributes, $content ) {
 	 $wp_query_args = array(
 		 'post_type' => 'post',
 		 'order'     => 'DESC',
 	 );
 
-	 $url_category_name = '';
 	 $link              = false;
 
 	 if ( isset( $block_attributes['categories'] ) and $block_attributes['categories'] != '' ) {
-		 $wp_query_args['category_name'] = $block_attributes['categories'];
-		 $url_category_name              = '&category_name=' . $block_attributes['categories'];
+ 		 $categoriesIds = map_slug_list_to_ids( $block_attributes['categories'] );
+		 $wp_query_args['cat'] = $categoriesIds;
+ 
+		 // archive button only links to first category
+		 $link = get_category_link( $categoriesIds[0] );
+	 }
 
-		 $categories = explode( ',', $block_attributes['categories'] );
-		 $link       = get_category_link( get_category_by_slug( trim( $categories[0] ) ) );
+	 if ( isset( $block_attributes['excludedCategories'] ) and $block_attributes['excludedCategories'] != '' ) {
+		 $categoriesIds = map_slug_list_to_ids( $block_attributes['excludedCategories'] );
+		 $wp_query_args['category__not_in'] = $categoriesIds;
 	 }
 
 	 if ( ! $link or $link == '' ) {

--- a/src/latest-posts.js
+++ b/src/latest-posts.js
@@ -18,6 +18,10 @@ registerBlockType( 'sunflower/latest-posts', {
 			type: 'string',
 			default: ''
 		},
+        excludedCategories: {
+			type: 'string',
+			default: ''
+		},
         count: {
 			type: 'string',
 			default: ''
@@ -34,6 +38,7 @@ registerBlockType( 'sunflower/latest-posts', {
         const {
             attributes: {
                 categories,
+                excludedCategories,
                 count,
                 title
             },
@@ -50,6 +55,10 @@ registerBlockType( 'sunflower/latest-posts', {
 
         const onChangeCategories = ( input ) => {
             props.setAttributes( { categories: input === undefined ? '' : input } );
+        };
+
+        const onChangeExcludedCategories = ( input ) => {
+            props.setAttributes( { excludedCategories: input === undefined ? '' : input } );
         };
 
         const onChangeCount = ( input ) => {
@@ -98,11 +107,19 @@ registerBlockType( 'sunflower/latest-posts', {
                         />
 
                         <TextControl
+                            label="Ausgeschlossene Kategorien"
+                            help="Kategorie-Slug(URL) eintragen. Mehrere mit Komma trennen."
+                            value={ excludedCategories }
+                            onChange={ onChangeExcludedCategories }
+                        />
+
+                        <TextControl
                             label="Anzahl"
                             help="Wieviele Beiträge sollen angezeigt werden"
                             value={ count }
                             onChange={ onChangeCount }
                         />
+
                     </PanelBody>
 
                  </InspectorControls>


### PR DESCRIPTION
Adds an option to exclude posts from the recent posts lists by category slug. Some sites have a long list of categories and only want to exclude one of them. In this case, listing all categories is cumbersome and the list needs to be kept in sync if new categories are added.

I also removed `$url_category_name`, which seems to be not in use?

![image](https://github.com/verdigado/sunflower/assets/4690162/c90f09e3-a262-4e9a-ba1d-004c4a9455de)


