### PR TITLE
textbalken add the font type

### DIFF
--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -167,6 +167,10 @@ h6,
     position: relative;
     padding: 0;
 
+    @include themed() {
+        font-family: t("headingFont");
+    }
+
     &.has-text-align-center {
         margin: auto;
     }


### PR DESCRIPTION
add the font type - so in every text type the font is like the heading type. It's regulate by Green CI.