### PR TITLE
fix(personal): Adjust logo to the same size as standard

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -279,7 +279,7 @@ body {
         }
 
         img {
-            width: 75px;
+            height: 56px;
         }
 
         #mainmenu {


### PR DESCRIPTION
This adjusts the size size of the sunflower logo on the header in personal mode the same size as in standard mode.

Before:
![Screenshot 2024-11-01 at 15-45-32 Grüne Mannheim](https://github.com/user-attachments/assets/ecf29e23-aa5f-46d9-a93b-5c15e5581200)

After:
![Screenshot 2024-11-01 at 17-10-23 Bündnis 90 Die Grünen](https://github.com/user-attachments/assets/13d0ac94-9ec6-4ccd-9d2e-c40dca0113a8)

