### PR TITLE
fix(personal): Adjust logo and title margins

### DIFF
--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -266,7 +266,7 @@ body {
                 background-color: $secondary;
             }
 
-            margin-right: 0.25rem;
+            margin-right: 1rem;
             height: 95px;
             width: 95px;
             display: flex;

--- a/template-parts/header-personal.php
+++ b/template-parts/header-personal.php
@@ -39,10 +39,10 @@
 						<?php printf( '<span>%s</span>', esc_attr( get_bloginfo( 'name' ) ) ); ?>
 					</div>
 					<?php
-						$description = get_bloginfo( 'description' );
-						if ( $description ) {
-							printf( '<div class="mb-0 bloginfo-description">%s</div>', esc_attr( $description ) );
-						}
+					$sunflower_description = get_bloginfo( 'description' );
+					if ( $sunflower_description ) {
+						printf( '<div class="mb-0 bloginfo-description">%s</div>', esc_attr( $sunflower_description ) );
+					}
 					?>
 				</div>
 			</div>

--- a/template-parts/header-personal.php
+++ b/template-parts/header-personal.php
@@ -39,7 +39,7 @@
 						<?php printf( '<span>%s</span>', esc_attr( get_bloginfo( 'name' ) ) ); ?>
 					</div>
 					<?php
-						$description = bloginfo( 'description' );
+						$description = get_bloginfo( 'description' );
 						if ( $description !== '' ) {
 							printf( '<div class="mb-0 bloginfo-description">%s</div>', esc_attr( $description ) );
 						}

--- a/template-parts/header-personal.php
+++ b/template-parts/header-personal.php
@@ -36,11 +36,14 @@
 				</div>
 				<div>
 					<div class="h5 bloginfo-name">
-						<p><?php printf( '<span>%s</span>', esc_attr( get_bloginfo( 'name' ) ) ); ?></p>
+						<?php printf( '<span>%s</span>', esc_attr( get_bloginfo( 'name' ) ) ); ?>
 					</div>
-					<div class="mb-0 bloginfo-description">
-						<?php esc_attr( bloginfo( 'description' ) ); ?>
-					</div>
+					<?php
+						$description = bloginfo( 'description' );
+						if ( $description !== '' ) {
+							printf( '<div class="mb-0 bloginfo-description">%s</div>', esc_attr( $description ) );
+						}
+					?>
 				</div>
 			</div>
 

--- a/template-parts/header-personal.php
+++ b/template-parts/header-personal.php
@@ -40,7 +40,7 @@
 					</div>
 					<?php
 						$description = get_bloginfo( 'description' );
-						if ( $description !== '' ) {
+						if ( $description ) {
 							printf( '<div class="mb-0 bloginfo-description">%s</div>', esc_attr( $description ) );
 						}
 					?>


### PR DESCRIPTION
This fixes the margins of title and logo making them more evenly space.

It also vertically centralizes the main title if the description / subtitle is empty.